### PR TITLE
NameError occured with ruby 2.1.3p242/redmine 2.5.2

### DIFF
--- a/app/controllers/repoindexer_controller.rb
+++ b/app/controllers/repoindexer_controller.rb
@@ -18,6 +18,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import RedmineReposearchPureEstraier
+
 class RepoindexerController < SysController
   unloadable
 

--- a/app/controllers/reposearch_controller.rb
+++ b/app/controllers/reposearch_controller.rb
@@ -18,6 +18,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import RedmineReposearchPureEstraier
+
 class ReposearchController < ApplicationController
   unloadable
   layout 'base'


### PR DESCRIPTION
NameError (uninitialized constant ReposearchController::RedmineReposearch):　 エラーを解消
ruby 2.1.3p242 および redmine 2.5.2 での動作を確認
